### PR TITLE
Fix invalid parameter in Notification converter

### DIFF
--- a/src/converter/notification.ts
+++ b/src/converter/notification.ts
@@ -61,7 +61,7 @@ export class Notification {
             notification.senderName = attr.sender_name;
         }
         if (attr.sender_id !== undefined) {
-            notification.senderId = attr.senderId;
+            notification.senderId = attr.sender_id;
         }
         if (attr.sender_url !== undefined) {
             notification.senderUrl = attr.sender_url;


### PR DESCRIPTION
incorrect: `senderId`
correct: `sender_id`

cf. [通知APIで使用するデータの構造 - cybozu developer network](https://developer.cybozu.io/hc/ja/articles/202495980#step1)